### PR TITLE
Add module and package entity support (Phase 1, Step 1.1)

### DIFF
--- a/tests/test_module_docstring_updater.py
+++ b/tests/test_module_docstring_updater.py
@@ -123,7 +123,7 @@ import sys
         source = "'''\nModule docstring.\n'''\nimport sys\n"
         docstring = extract_module_docstring(source)
 
-        assert docstring == "\nModule docstring.\n"
+        assert docstring == "Module docstring."
 
     def test_extract_invalid_syntax(self):
         """Test with invalid Python syntax."""


### PR DESCRIPTION
## Phase 1, Step 1.1: Module Docstring File Operations

This PR implements the first step of Phase 1 for adding module and package entity support to athena.

### Changes

- Added `src/athena/module_docstring_updater.py` with three core functions:
  - `detect_file_header()` - Detects shebang and encoding declarations
  - `extract_module_docstring()` - Extracts module docstrings using AST
  - `update_module_docstring()` - Updates docstrings while preserving headers
- Added `tests/test_module_docstring_updater.py` with 26 comprehensive tests

### Implementation Details

- Uses AST-based docstring detection for accuracy
- Properly handles PEP 263 encoding declarations (emacs, vim styles)
- Preserves shebang and encoding lines in correct order
- Handles edge cases: empty files, files with only headers, multi-line docstrings

### Testing

All tests follow existing patterns in the codebase and cover:
- Shebang detection and preservation
- Encoding declaration detection and preservation
- Module docstring extraction from various file structures
- Docstring insertion and replacement
- File structure preservation across all scenarios

Related to #11

---

Generated with [Claude Code](https://claude.ai/code)