### PR TITLE
Implement package entity inspection (Phase 2, Step 2.3)

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -416,17 +416,6 @@ def foo():
             assert "@athena:" in updated_code
             assert '"""' in updated_code
 
-    def test_sync_package_level_not_implemented(self):
-        """Test that package-level sync raises NotImplementedError."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            repo_root = Path(tmpdir)
-            package_dir = repo_root / "mypackage"
-            package_dir.mkdir()
-            (package_dir / "__init__.py").write_text("")
-
-            with pytest.raises(NotImplementedError, match="Package-level"):
-                sync_entity("mypackage", force=False, repo_root=repo_root)
-
     def test_sync_preserves_existing_docstring_content(self):
         """Test that sync preserves existing docstring content."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
### Phase 2, Step 2.3: Package Entity Inspection

Implements package entity inspection functionality to enable athena to inspect packages and compute their hashes.

### Changes

- Modified `src/athena/sync.py`:
  - Added imports for `compute_package_hash` and package utilities
  - Replaced `NotImplementedError` for packages with full inspection logic
  - Reads __init__.py (or uses empty string if missing)
  - Gets package manifest via `get_package_manifest()`
  - Computes hash via `compute_package_hash()`
  - Extracts docstring from __init__.py and parses @athena tag
  - Returns `EntityStatus` with dummy extent (packages are directories)

- Added tests in `tests/test_sync.py`:
  - `test_inspect_package_empty_init` - Empty __init__.py handling
  - `test_inspect_package_with_init_code` - Package with code in __init__.py
  - `test_inspect_package_with_docstring_no_tag` - Docstring without tag
  - `test_inspect_package_with_tag` - Existing @athena tag
  - `test_inspect_package_hash_reflects_structure` - Hash changes with structure

### Implementation Details

Package inspection follows the same pattern as module inspection:
1. Resolve package directory path
2. Read __init__.py and get package manifest
3. Compute package hash based on __init__.py + manifest
4. Extract package docstring from __init__.py
5. Parse @athena tag from docstring
6. Return `EntityStatus` with all information

Package extent is a dummy (0, 0) since packages are directories, not line ranges.

### Testing

All tests cover:
- Empty __init__.py files
- Packages with code in __init__.py
- Package docstrings with/without @athena tags
- Hash changes when file structure changes

Related to #11

---

Generated with [Claude Code](https://claude.ai/code)