### PR TITLE
Add SearchResult model for BM25 search feature

### DIFF
--- a/src/athena/models.py
+++ b/src/athena/models.py
@@ -86,5 +86,14 @@ class EntityStatus:
     calculated_hash: str  # Hash computed from AST
 
 
+@dataclass
+class SearchResult:
+    """Represents a search result with entity details and docstring summary."""
+    kind: str
+    path: str
+    extent: Location
+    summary: str
+
+
 # Union type for entity info
 EntityInfo = FunctionInfo | ClassInfo | MethodInfo | ModuleInfo | PackageInfo

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,6 +10,7 @@ from athena.models import (
     ModuleInfo,
     PackageInfo,
     Parameter,
+    SearchResult,
     Signature,
 )
 
@@ -344,3 +345,50 @@ def test_entity_status_module_no_extent():
     )
 
     assert status.extent == ""
+
+
+def test_search_result_creation():
+    location = Location(start=10, end=25)
+    result = SearchResult(
+        kind="function",
+        path="src/auth.py",
+        extent=location,
+        summary="Validates JWT token and returns user object."
+    )
+
+    assert result.kind == "function"
+    assert result.path == "src/auth.py"
+    assert result.extent == location
+    assert result.summary == "Validates JWT token and returns user object."
+
+
+def test_search_result_to_dict():
+    location = Location(start=15, end=30)
+    result = SearchResult(
+        kind="class",
+        path="src/models.py",
+        extent=location,
+        summary="User authentication model."
+    )
+
+    result_dict = asdict(result)
+
+    assert result_dict == {
+        "kind": "class",
+        "path": "src/models.py",
+        "extent": {"start": 15, "end": 30},
+        "summary": "User authentication model."
+    }
+
+
+def test_search_result_multiline_summary():
+    location = Location(start=5, end=20)
+    result = SearchResult(
+        kind="method",
+        path="src/service.py",
+        extent=location,
+        summary="Process user request.\n\nThis method handles authentication and validation."
+    )
+
+    assert result.summary == "Process user request.\n\nThis method handles authentication and validation."
+    assert "\n\n" in result.summary


### PR DESCRIPTION
Add SearchResult dataclass to models.py for representing search results with entity details and docstring summaries. Includes comprehensive unit tests for creation, serialization, and multi-line summary handling.

This is the first step (Phase 1, Step 1) of implementing the BM25 docstring search feature.

Related to #26

---

Generated with [Claude Code](https://claude.ai/code)