### PR TITLE
Add configuration infrastructure for BM25 search

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "tree-sitter-python>=0.21.0",
     "mcp>=1.0.0",
     "rich>=14.2.0",
+    "pyyaml>=6.0",
+    "rank-bm25>=0.2.2",
 ]
 
 [project.scripts]

--- a/src/athena/config.py
+++ b/src/athena/config.py
@@ -1,0 +1,96 @@
+"""Configuration management for athena search functionality."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class SearchConfig:
+    """Configuration for BM25 search parameters.
+
+    Attributes:
+        term_frequency_saturation: Controls how quickly term frequency
+            influence saturates (k1 parameter in BM25). Range: [1.2, 2.0].
+        length_normalization: Controls document length normalization
+            (b parameter in BM25). Range: [0.5, 0.75].
+        max_results: Maximum number of search results to return.
+    """
+    term_frequency_saturation: float = 1.5
+    length_normalization: float = 0.75
+    max_results: int = 10
+
+    @property
+    def k1(self) -> float:
+        """BM25 k1 parameter (term frequency saturation)."""
+        return self.term_frequency_saturation
+
+    @property
+    def b(self) -> float:
+        """BM25 b parameter (length normalization)."""
+        return self.length_normalization
+
+    @property
+    def k(self) -> int:
+        """Number of results to return."""
+        return self.max_results
+
+
+def load_search_config(repo_root: Path | None = None) -> SearchConfig:
+    """Load search configuration from .athena file in repository root.
+
+    Args:
+        repo_root: Path to repository root. If None, uses current directory.
+
+    Returns:
+        SearchConfig object with loaded or default values.
+
+    Notes:
+        If .athena file doesn't exist or can't be parsed, returns default config.
+        Expected YAML structure:
+
+        ```yaml
+        search:
+          term_frequency_saturation: 1.5
+          length_normalization: 0.75
+          max_results: 10
+        ```
+    """
+    if repo_root is None:
+        repo_root = Path.cwd()
+
+    config_path = repo_root / ".athena"
+
+    if not config_path.exists():
+        return SearchConfig()
+
+    try:
+        with open(config_path, "r") as f:
+            data = yaml.safe_load(f)
+
+        if not isinstance(data, dict):
+            return SearchConfig()
+
+        search_config = data.get("search", {})
+        if not isinstance(search_config, dict):
+            return SearchConfig()
+
+        return SearchConfig(
+            term_frequency_saturation=search_config.get(
+                "term_frequency_saturation",
+                SearchConfig.term_frequency_saturation
+            ),
+            length_normalization=search_config.get(
+                "length_normalization",
+                SearchConfig.length_normalization
+            ),
+            max_results=search_config.get(
+                "max_results",
+                SearchConfig.max_results
+            ),
+        )
+    except (yaml.YAMLError, OSError, KeyError, TypeError, ValueError):
+        # Return default config on any parsing errors
+        return SearchConfig()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,175 @@
+"""Tests for config module."""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from athena.config import SearchConfig, load_search_config
+
+
+class TestSearchConfig:
+    """Tests for SearchConfig dataclass."""
+
+    def test_default_values(self):
+        """Test that SearchConfig has correct default values."""
+        config = SearchConfig()
+        assert config.term_frequency_saturation == 1.5
+        assert config.length_normalization == 0.75
+        assert config.max_results == 10
+
+    def test_custom_values(self):
+        """Test creating SearchConfig with custom values."""
+        config = SearchConfig(
+            term_frequency_saturation=1.8,
+            length_normalization=0.6,
+            max_results=20
+        )
+        assert config.term_frequency_saturation == 1.8
+        assert config.length_normalization == 0.6
+        assert config.max_results == 20
+
+    def test_k1_property(self):
+        """Test k1 property returns term_frequency_saturation."""
+        config = SearchConfig(term_frequency_saturation=1.8)
+        assert config.k1 == 1.8
+
+    def test_b_property(self):
+        """Test b property returns length_normalization."""
+        config = SearchConfig(length_normalization=0.6)
+        assert config.b == 0.6
+
+    def test_k_property(self):
+        """Test k property returns max_results."""
+        config = SearchConfig(max_results=20)
+        assert config.k == 20
+
+
+class TestLoadSearchConfig:
+    """Tests for load_search_config function."""
+
+    def test_no_config_file_returns_defaults(self):
+        """Test that missing .athena file returns default config."""
+        with TemporaryDirectory() as tmpdir:
+            config = load_search_config(Path(tmpdir))
+            assert config.term_frequency_saturation == 1.5
+            assert config.length_normalization == 0.75
+            assert config.max_results == 10
+
+    def test_load_valid_config(self):
+        """Test loading valid .athena configuration file."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / ".athena"
+            config_path.write_text("""
+search:
+  term_frequency_saturation: 1.8
+  length_normalization: 0.6
+  max_results: 20
+""")
+            config = load_search_config(Path(tmpdir))
+            assert config.term_frequency_saturation == 1.8
+            assert config.length_normalization == 0.6
+            assert config.max_results == 20
+
+    def test_load_partial_config(self):
+        """Test loading config with only some values specified."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / ".athena"
+            config_path.write_text("""
+search:
+  term_frequency_saturation: 1.8
+""")
+            config = load_search_config(Path(tmpdir))
+            assert config.term_frequency_saturation == 1.8
+            assert config.length_normalization == 0.75  # default
+            assert config.max_results == 10  # default
+
+    def test_empty_config_file_returns_defaults(self):
+        """Test that empty .athena file returns default config."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / ".athena"
+            config_path.write_text("")
+            config = load_search_config(Path(tmpdir))
+            assert config.term_frequency_saturation == 1.5
+            assert config.length_normalization == 0.75
+            assert config.max_results == 10
+
+    def test_missing_search_section_returns_defaults(self):
+        """Test that .athena file without search section returns defaults."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / ".athena"
+            config_path.write_text("""
+other_section:
+  some_key: some_value
+""")
+            config = load_search_config(Path(tmpdir))
+            assert config.term_frequency_saturation == 1.5
+            assert config.length_normalization == 0.75
+            assert config.max_results == 10
+
+    def test_invalid_yaml_returns_defaults(self):
+        """Test that invalid YAML returns default config."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / ".athena"
+            config_path.write_text("invalid: yaml: content: [")
+            config = load_search_config(Path(tmpdir))
+            assert config.term_frequency_saturation == 1.5
+            assert config.length_normalization == 0.75
+            assert config.max_results == 10
+
+    def test_wrong_type_search_section_returns_defaults(self):
+        """Test that non-dict search section returns defaults."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / ".athena"
+            config_path.write_text("search: not_a_dict")
+            config = load_search_config(Path(tmpdir))
+            assert config.term_frequency_saturation == 1.5
+            assert config.length_normalization == 0.75
+            assert config.max_results == 10
+
+    def test_wrong_type_root_returns_defaults(self):
+        """Test that non-dict root returns defaults."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / ".athena"
+            config_path.write_text("- list\n- not\n- dict")
+            config = load_search_config(Path(tmpdir))
+            assert config.term_frequency_saturation == 1.5
+            assert config.length_normalization == 0.75
+            assert config.max_results == 10
+
+    def test_none_repo_root_uses_cwd(self):
+        """Test that None repo_root uses current working directory."""
+        # This test just verifies the function doesn't crash with None
+        config = load_search_config(None)
+        assert isinstance(config, SearchConfig)
+
+    def test_unreadable_file_returns_defaults(self):
+        """Test that file read errors return default config."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / ".athena"
+            config_path.write_text("search:\n  max_results: 20")
+            # Make file unreadable (on Unix-like systems)
+            try:
+                config_path.chmod(0o000)
+                config = load_search_config(Path(tmpdir))
+                assert config.term_frequency_saturation == 1.5
+                assert config.length_normalization == 0.75
+                assert config.max_results == 10
+            finally:
+                # Restore permissions for cleanup
+                config_path.chmod(0o644)
+
+    def test_config_with_extra_fields(self):
+        """Test that extra fields in config are ignored."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / ".athena"
+            config_path.write_text("""
+search:
+  term_frequency_saturation: 1.8
+  extra_field: ignored
+  max_results: 20
+""")
+            config = load_search_config(Path(tmpdir))
+            assert config.term_frequency_saturation == 1.8
+            assert config.max_results == 20
+            assert not hasattr(config, 'extra_field')


### PR DESCRIPTION
Add configuration module for BM25 docstring search feature with YAML-based config file support.

## Changes

- Add pyyaml and rank-bm25 dependencies to pyproject.toml
- Create config.py with SearchConfig dataclass and load_search_config()
- Use meaningful parameter names in YAML (term_frequency_saturation, length_normalization, max_results)
- Add convenience properties (k1, b, k) for BM25 algorithm usage
- Create comprehensive tests covering all scenarios and edge cases

This is Phase 1, Step 2 of implementing the BM25 docstring search feature.

Related to #26

---

Generated with [Claude Code](https://claude.ai/code)