### PR TITLE
Phase 5.2: Add transaction management

### DIFF
--- a/src/athena/cache.py
+++ b/src/athena/cache.py
@@ -231,16 +231,19 @@ class CacheDatabase:
 
         Raises:
             RuntimeError: If database connection not initialized.
+            ValueError: If file_id does not exist.
             sqlite3.Error: If database operation fails.
         """
         if self.conn is None:
             raise RuntimeError("Database connection not initialized")
 
         try:
-            self.conn.execute(
+            cursor = self.conn.execute(
                 "UPDATE files SET mtime = ? WHERE id = ?",
                 (mtime, file_id)
             )
+            if cursor.rowcount == 0:
+                raise ValueError(f"File with id {file_id} not found")
             if not self._in_transaction:
                 self.conn.commit()
         except sqlite3.Error as e:


### PR DESCRIPTION
### Summary

Implements Phase 5.2 of issue #35: Add proper transaction management to cache database.

### Changes
- Add `transaction()` context manager to CacheDatabase
- Update all DB methods to respect transaction context
- Refactor search.py to use transactions for grouped operations
- 8 comprehensive unit tests for transaction behavior

### Benefits
- Improved concurrency with shorter transaction windows
- Atomicity: Related operations succeed or fail together
- Better performance (fewer commits)
- No partial cache updates

### Testing
- All new tests in `tests/test_cache.py`
- Tests cover success, rollback, atomicity, nesting, and edge cases

Related to #35 (Phase 5.2)

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/kevinchannon/athena/actions/runs/21277223113) | [Branch](https://github.com/kevinchannon/athena/tree/claude/issue-35-20260123-0642