### PR TITLE
Add FTS5 virtual table schema to cache

### DIFF
--- a/src/athena/cache.py
+++ b/src/athena/cache.py
@@ -102,6 +102,15 @@ class CacheDatabase:
         """)
 
         self.conn.execute("""
+            CREATE VIRTUAL TABLE IF NOT EXISTS entities_fts
+            USING fts5(
+                entity_id UNINDEXED,
+                summary,
+                tokenize='porter unicode61'
+            )
+        """)
+
+        self.conn.execute("""
             CREATE INDEX IF NOT EXISTS idx_file_path ON files(file_path)
         """)
 


### PR DESCRIPTION
Implements step 1.1 of issue #46: Add FTS5 virtual table schema

## Changes
- Create `entities_fts` virtual table with porter unicode61 tokenizer
- Add entity_id (UNINDEXED) and summary columns
- Update test to verify FTS5 table creation
- Add specific test for FTS5 table configuration and querying

Related to #46

Generated with [Claude Code](https://claude.ai/code)