### PR TITLE
Replace BM25 search with two-tier FTS5 strategy

### DIFF
--- a/src/athena/cache.py
+++ b/src/athena/cache.py
@@ -570,7 +570,11 @@ class CacheDatabase:
                 # FTS5 defaults to AND, so we need explicit OR operators
                 # Remove FTS5 special characters that could cause syntax errors
                 sanitized_query = re.sub(r'[^\w\s-]', ' ', query)
-                terms = [t for t in sanitized_query.split() if t and t.upper() not in ('OR', 'AND', 'NOT')]
+                # Filter out: empty strings, standalone hyphens, FTS5 operators, and tokens that are just punctuation
+                terms = [
+                    t for t in sanitized_query.split()
+                    if t and t != '-' and t.upper() not in ('OR', 'AND', 'NOT') and re.search(r'\w', t)
+                ]
                 or_query = " OR ".join(terms) if terms else ""
 
                 # Return empty if no valid terms

--- a/src/athena/cache.py
+++ b/src/athena/cache.py
@@ -55,25 +55,48 @@ class CacheDatabase:
     def _open(self) -> None:
         """Open database connection and initialize schema.
 
+        Retries on "database is locked" errors to handle concurrent cache creation.
+
         Raises:
-            sqlite3.Error: If database cannot be opened or initialized.
+            sqlite3.Error: If database cannot be opened or initialized after retries.
         """
-        try:
-            self.conn = sqlite3.connect(
-                str(self.db_path),
-                check_same_thread=False,
-                timeout=10.0  # 10 second timeout for busy database
-            )
-            self.conn.execute("PRAGMA foreign_keys = ON")
-            self.conn.execute("PRAGMA journal_mode = WAL")
-            self.conn.execute("PRAGMA busy_timeout = 10000")  # 10 seconds in milliseconds
-            self.create_tables()
-        except sqlite3.Error as e:
-            logger.error(f"Failed to open cache database at {self.db_path}: {e}")
-            if self.conn:
-                self.conn.close()
-                self.conn = None
-            raise
+        import time
+
+        max_retries = 3
+        retry_delay = 0.1  # 100ms
+
+        for attempt in range(max_retries):
+            try:
+                self.conn = sqlite3.connect(
+                    str(self.db_path),
+                    check_same_thread=False,
+                    timeout=10.0  # 10 second timeout for busy database
+                )
+                self.conn.execute("PRAGMA foreign_keys = ON")
+                self.conn.execute("PRAGMA journal_mode = WAL")
+                self.conn.execute("PRAGMA busy_timeout = 10000")  # 10 seconds in milliseconds
+                self.create_tables()
+                return  # Success
+            except sqlite3.OperationalError as e:
+                if "database is locked" in str(e) and attempt < max_retries - 1:
+                    # Retry after a brief delay
+                    if self.conn:
+                        self.conn.close()
+                        self.conn = None
+                    time.sleep(retry_delay)
+                    continue
+                # Re-raise if not a lock error or out of retries
+                logger.error(f"Failed to open cache database at {self.db_path}: {e}")
+                if self.conn:
+                    self.conn.close()
+                    self.conn = None
+                raise
+            except sqlite3.Error as e:
+                logger.error(f"Failed to open cache database at {self.db_path}: {e}")
+                if self.conn:
+                    self.conn.close()
+                    self.conn = None
+                raise
 
     def create_tables(self) -> None:
         """Create database schema if it doesn't exist."""

--- a/src/athena/search.py
+++ b/src/athena/search.py
@@ -300,8 +300,12 @@ def _scan_repo_with_cache(root: Path, cache_db: CacheDatabase) -> list[tuple[str
     # Clean up deleted files from cache
     cache_db.delete_files_not_in(seen_files)
 
-    # Return empty list - we'll query FTS5 directly instead of loading all entities
-    return []
+    # Return all entities from cache
+    all_entities = cache_db.get_all_entities()
+    return [
+        (kind, path, Location(start=start, end=end), summary)
+        for kind, path, start, end, summary in all_entities
+    ]
 
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -348,6 +348,42 @@ def test_get_all_entities_multiple_files(cache_db):
     assert "src/file2.py" in file_paths
 
 
+def test_get_entity_by_id(cache_db):
+    """Test retrieving a single entity by ID."""
+    file_id = cache_db.insert_file("src/module.py", 1234567890.0)
+
+    cache_db.insert_entities(file_id, [
+        CachedEntity(file_id, "function", "foo", "src/module.py:foo", 10, 20, "Foo function"),
+        CachedEntity(file_id, "class", "Bar", "src/module.py:Bar", 25, 50, "Bar class")
+    ])
+
+    # Get the first entity (ID should be 1)
+    entity = cache_db.get_entity_by_id(1)
+    assert entity is not None
+    kind, path, start, end, summary = entity
+    assert kind == "function"
+    assert path == "src/module.py"
+    assert start == 10
+    assert end == 20
+    assert summary == "Foo function"
+
+    # Get the second entity (ID should be 2)
+    entity = cache_db.get_entity_by_id(2)
+    assert entity is not None
+    kind, path, start, end, summary = entity
+    assert kind == "class"
+    assert path == "src/module.py"
+    assert start == 25
+    assert end == 50
+    assert summary == "Bar class"
+
+
+def test_get_entity_by_id_nonexistent(cache_db):
+    """Test retrieving a non-existent entity returns None."""
+    entity = cache_db.get_entity_by_id(999)
+    assert entity is None
+
+
 def test_context_manager(temp_cache_dir):
     """Test that context manager properly opens and closes database."""
     with CacheDatabase(temp_cache_dir) as db:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,5 +1,6 @@
 """Tests for the SQLite cache database."""
 
+import sqlite3
 import tempfile
 from pathlib import Path
 
@@ -102,11 +103,11 @@ def test_file_lookup_nonexistent(cache_db):
 
 
 def test_duplicate_file_insertion(cache_db):
-    """Test that duplicate file paths raise an error."""
+    """Test that duplicate file paths raise an IntegrityError."""
     cache_db.insert_file("src/example.py", 1234567890.0)
 
-    # Attempting to insert same path should fail
-    with pytest.raises(Exception):  # sqlite3.IntegrityError
+    # Attempting to insert same path should fail with IntegrityError
+    with pytest.raises(sqlite3.IntegrityError):
         cache_db.insert_file("src/example.py", 9999999999.0)
 
 


### PR DESCRIPTION
Implements Stage 2.1 of issue #46: Replace BM25 search with FTS5

## Changes
- Update search.py to use FTS5 phrase and word queries
- Implement two-tier search: exact phrase matches first, then standard FTS5
- Remove BM25Searcher import and fallback to non-cached search
- Add get_entity_by_id() method to CacheDatabase
- Update tests to expect errors instead of fallback behavior
- Add tests for get_entity_by_id() method

## Key Behavior Changes
- Exact phrase matches now rank first (Tier 1)
- Standard FTS5 matches fill remaining slots (Tier 2)
- Cache errors now propagate (no silent fallback)
- Net reduction: 66 lines of code

Related to #46

Generated with [Claude Code](https://claude.ai/code)