### PR TITLE
Simplify SearchConfig to max_results only

### DIFF
--- a/src/athena/README.md
+++ b/src/athena/README.md
@@ -91,9 +91,7 @@ Search also supports JSON output for programmatic use:
 Configuration can be customized via a `.athena` file in your repository root:
 ```yaml
 search:
-  term_frequency_saturation: 1.5  # BM25 k1 parameter (1.2-2.0)
-  length_normalization: 0.75      # BM25 b parameter (0.5-0.75)
-  max_results: 10                 # Default number of results
+  max_results: 10  # Default number of results
 ```
 
 Once you know where a thing is, then you can ask for info about it:

--- a/src/athena/cli.py
+++ b/src/athena/cli.py
@@ -97,11 +97,7 @@ def search(
         if max_results is not None:
             # Create new config with overridden max_results
             from athena.config import SearchConfig
-            config = SearchConfig(
-                term_frequency_saturation=config.k1,
-                length_normalization=config.b,
-                max_results=max_results
-            )
+            config = SearchConfig(max_results=max_results)
 
         results = search_docstrings(query, config=config)
 

--- a/src/athena/config.py
+++ b/src/athena/config.py
@@ -9,33 +9,12 @@ import yaml
 
 @dataclass
 class SearchConfig:
-    """Configuration for BM25 search parameters.
+    """Configuration for FTS5 search.
 
     Attributes:
-        term_frequency_saturation: Controls how quickly term frequency
-            influence saturates (k1 parameter in BM25). Range: [1.2, 2.0].
-        length_normalization: Controls document length normalization
-            (b parameter in BM25). Range: [0.5, 0.75].
         max_results: Maximum number of search results to return.
     """
-    term_frequency_saturation: float = 1.5
-    length_normalization: float = 0.75
     max_results: int = 10
-
-    @property
-    def k1(self) -> float:
-        """BM25 k1 parameter (term frequency saturation)."""
-        return self.term_frequency_saturation
-
-    @property
-    def b(self) -> float:
-        """BM25 b parameter (length normalization)."""
-        return self.length_normalization
-
-    @property
-    def k(self) -> int:
-        """Number of results to return."""
-        return self.max_results
 
 
 def load_search_config(repo_root: Path | None = None) -> SearchConfig:
@@ -53,8 +32,6 @@ def load_search_config(repo_root: Path | None = None) -> SearchConfig:
 
         ```yaml
         search:
-          term_frequency_saturation: 1.5
-          length_normalization: 0.75
           max_results: 10
         ```
     """
@@ -78,14 +55,6 @@ def load_search_config(repo_root: Path | None = None) -> SearchConfig:
             return SearchConfig()
 
         return SearchConfig(
-            term_frequency_saturation=search_config.get(
-                "term_frequency_saturation",
-                SearchConfig.term_frequency_saturation
-            ),
-            length_normalization=search_config.get(
-                "length_normalization",
-                SearchConfig.length_normalization
-            ),
             max_results=search_config.get(
                 "max_results",
                 SearchConfig.max_results


### PR DESCRIPTION
Implements Stage 4 of issue #46: Simplify Configuration

## Changes
- Remove BM25-specific parameters from SearchConfig (term_frequency_saturation, length_normalization)
- Remove BM25 properties (k1, b, k) from SearchConfig
- Update config loading to only parse max_results
- Update all tests to only check max_results
- Remove BM25 parameter references from CLI
- Update README configuration example

## Summary
- 4 incremental commits
- 84 lines of code removed
- All BM25 configuration references removed

Related to #46

Generated with [Claude Code](https://claude.ai/code)