### PR TITLE
Complete FTS5 migration: Update tests and documentation

### DIFF
--- a/src/athena/README.md
+++ b/src/athena/README.md
@@ -77,7 +77,7 @@ If you want to search for entities based on what they do (rather than their name
  function  src/athena/parsers/utils.py      45-67    Parse a Python file and return its AST
 ```
 
-The search command uses BM25 ranking to find the most relevant entities based on their docstrings. You can customize the number of results:
+The search command uses FTS5 full-text search to find the most relevant entities based on their docstrings. Exact phrase matches rank highest, followed by standard FTS5-scored results. You can customize the number of results:
 ```bash
 > athena search --max-results 5 "authentication"
 > athena search -k 3 "JWT token"  # Short form

--- a/src/athena/cache.py
+++ b/src/athena/cache.py
@@ -523,14 +523,14 @@ class CacheDatabase:
         """Query for exact phrase matches.
 
         Uses FTS5 phrase syntax to find entities where the summary contains
-        the exact query string as a phrase. Results are ranked by BM25.
+        the exact query string as a phrase. Results are ranked by FTS5's internal scoring.
 
         Args:
             query: Search query string (will be searched as exact phrase)
             limit: Maximum number of entity IDs to return
 
         Returns:
-            List of entity IDs matching the phrase, ordered by BM25 rank (best first)
+            List of entity IDs matching the phrase, ordered by relevance (best first)
 
         Raises:
             RuntimeError: If database connection not initialized.
@@ -566,7 +566,7 @@ class CacheDatabase:
     def query_words(self, query: str, limit: int, exclude_ids: set[int]) -> list[int]:
         """Query for individual words (OR'd together).
 
-        Terms can appear anywhere in the text. Results are ranked by BM25.
+        Terms can appear anywhere in the text. Results are ranked by FTS5's internal scoring.
 
         Args:
             query: Search query string (terms will be OR'd together)
@@ -574,7 +574,7 @@ class CacheDatabase:
             exclude_ids: Set of entity IDs to exclude from results (e.g., already matched by phrase search)
 
         Returns:
-            List of entity IDs matching the query, ordered by BM25 rank (best first),
+            List of entity IDs matching the query, ordered by relevance (best first),
             excluding any IDs in exclude_ids
 
         Raises:

--- a/src/athena/cli.py
+++ b/src/athena/cli.py
@@ -74,10 +74,11 @@ def search(
     json: bool = typer.Option(False, "--json", "-j", help="Output as JSON instead of table"),
     max_results: Optional[int] = typer.Option(None, "--max-results", "-k", help="Maximum number of results to return"),
 ):
-    """Search docstrings using BM25 ranking.
+    """Search docstrings using FTS5 full-text search.
 
     Searches all docstrings in the repository using natural language queries
-    with BM25 ranking algorithm and code-aware tokenization.
+    with FTS5 full-text search and two-tier ranking (exact phrase matches first,
+    then standard FTS5 matches).
 
     Args:
         query: Natural language search query
@@ -87,7 +88,7 @@ def search(
     Examples:
         athena search "JWT authentication"
         athena search "parse configuration file" --max-results 5
-        athena search "BM25 scoring" --json
+        athena search "full text search" --json
     """
     try:
         # Load config and override max_results if specified

--- a/src/athena/search.py
+++ b/src/athena/search.py
@@ -1,7 +1,8 @@
 """FTS5-based docstring search for code navigation.
 
 This module provides efficient docstring-based search functionality using SQLite
-FTS5 (Full-Text Search) with BM25 ranking and SQLite-based caching.
+FTS5 (Full-Text Search) with SQLite-based caching. FTS5 uses BM25 ranking internally
+to score search results.
 """
 
 import logging
@@ -266,7 +267,7 @@ def _process_file_with_cache(
 
     # File is up-to-date in cache - no need to parse
     # We don't return cached entities here since we'll load all entities
-    # at once in the next phase for BM25 search
+    # at once in the next phase for FTS5 search
     return []
 
 
@@ -324,7 +325,7 @@ def search_docstrings(
 
     Uses a two-tier search approach:
     1. Tier 1: Exact phrase matches (highest priority)
-    2. Tier 2: Standard FTS5 matches with BM25 ranking (if needed to fill max_results)
+    2. Tier 2: Standard FTS5 matches (if needed to fill max_results)
 
     Args:
         query: Natural language search query.
@@ -332,7 +333,7 @@ def search_docstrings(
         config: Search configuration. If None, loads from .athena file.
 
     Returns:
-        List of SearchResult objects sorted by relevance (phrase matches first, then BM25).
+        List of SearchResult objects sorted by relevance (phrase matches first, then FTS5 scored).
         Returns empty list if query is empty or no matches found.
 
     Raises:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1324,7 +1324,7 @@ def test_query_words_empty_exclude_set(cache_db):
 
 
 def test_query_words_bm25_ranking(cache_db):
-    """Test standard query ranks documents by BM25 score."""
+    """Test standard query ranks documents by FTS5 relevance score."""
     file_id = cache_db.insert_file("src/example.py", 1234567890.0)
 
     cache_db.insert_entities(file_id, [
@@ -1346,7 +1346,7 @@ def test_query_words_bm25_ranking(cache_db):
     )
     names = [row[0] for row in cursor.fetchall()]
 
-    # First result should be func1 (highest BM25 score)
+    # First result should be func1 (highest FTS5 score)
     assert names[0] == "func1"
 
 
@@ -1455,8 +1455,8 @@ def test_fts5_ranking_fts_aligned(cache_db):
     # Test 2: No phrase, full term coverage
     # Query: "one three five"
     # Expected: Docs 1, 4, 6 contain all three terms
-    # Note: With OR logic, FTS5 BM25 doesn't guarantee docs with more matching terms
-    # rank higher - shorter docs matching fewer terms well can rank higher.
+    # Note: With OR logic, FTS5 doesn't guarantee docs with more matching terms
+    # rank higher - shorter docs matching fewer terms can rank higher due to length normalization.
     standard_results = cache_db.query_words("one three five", limit=10, exclude_ids=set())
 
     # Verify that docs containing the terms are present (but not ordering)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -316,8 +316,7 @@ class TestSearchDocstrings:
         file.write_text('"""Authentication module."""\n')
 
         results = search_docstrings("xyzabc123notfound", root=tmp_path)
-        # BM25 might return low-scored results, but with proper tokenization
-        # completely unrelated terms should return empty or very low scores
+        # FTS5 might return low-scored results for unrelated terms
         # For this test, we just verify it doesn't crash
         assert isinstance(results, list)
 
@@ -349,7 +348,7 @@ class Auth:
         assert "method" in kinds
 
     def test_search_ranking_order(self, tmp_path):
-        """Verify results are returned in descending BM25 score order."""
+        """Verify results are returned in descending FTS5 relevance order."""
         (tmp_path / ".git").mkdir()
         file1 = tmp_path / "exact.py"
         file1.write_text('"""JWT authentication handler."""\n')
@@ -398,7 +397,7 @@ class Auth:
         # This test should work if run from within athena repository
         # Just verify it doesn't crash
         try:
-            results = search_docstrings("BM25", root=None)
+            results = search_docstrings("search", root=None)
             assert isinstance(results, list)
         except RepositoryNotFoundError:
             # If we're not in a git repo, that's expected


### PR DESCRIPTION
## Summary

Completes Stages 5 and 6 of issue #46: FTS5 migration

## Changes

**Stage 5: Test Updates**
- Updated test comments to reference FTS5 instead of BM25
- Changed test query from "BM25" to "search" for clarity
- Updated test docstrings to reflect FTS5 ranking behavior

**Stage 6: Documentation Updates**
- Updated module docstrings in search.py and cache.py
- Updated CLI help text to describe FTS5 two-tier search
- Updated README to mention FTS5 full-text search
- Replaced BM25 ranking references with FTS5 scoring
- Removed references to code-aware tokenization

## Files Modified
- `tests/test_search.py`
- `tests/test_cache.py`
- `src/athena/search.py`
- `src/athena/cache.py`
- `src/athena/cli.py`
- `src/athena/README.md`

## Testing
Please run `pytest tests/test_cache.py tests/test_search.py` to verify all tests pass.

Related to #46

Generated with [Claude Code](https://claude.ai/code)) | [Branch](https://github.com/kevinchannon/athena/tree/claude/issue-46-20260124-0851) | [View job run](https://github.com/kevinchannon/athena/actions/runs/21312477997